### PR TITLE
fix: add access secrets from the secrets portal

### DIFF
--- a/io.ente.auth.yml
+++ b/io.ente.auth.yml
@@ -14,6 +14,8 @@ finish-args:
   # For desktop notifications
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
+  # Required to access secrets from the secrets portal
+  - --talk-name=org.freedesktop.secrets
   # For fingerprint authentication
   - --system-talk-name=net.reactivated.Fprint
 rename-appdata-file: enteauth.appdata.xml


### PR DESCRIPTION
## Motivation and context

Resolve black screen issue and error without this access.

Stolen from:
- https://github.com/flathub/app.drey.KeyRack/blob/77b6f3c4e8c5a4b30e2b9c69316e1a5c3b151a2a/app.drey.KeyRack.yml#L19-L20

![image](https://github.com/user-attachments/assets/0cc3cd9c-d27b-4996-930d-fb17224881a0)

```shell
$ flatpak run io.ente.auth
flutter:  [ente_logging] [INFO] [2024-10-13 00:36:46.656872] log file for today: File: '/home/wgimenes/.var/app/io.ente.auth/data/enteauth/logs/2024-10-13.txt' with prefix
flutter: [ente_logging] [INFO] [2024-10-13 00:36:46.656872] app version: '4.0.3+403'
flutter: [ente_logging] [INFO] [2024-10-13 00:36:46.656872]
flutter:  [main] [INFO] [2024-10-13 00:36:46.656935] Starting app in foreground
flutter:  [Configuration] [INFO] [2024-10-13 00:36:46.657025] Skipping temp folder clear

** (enteauth:2): WARNING **: 00:36:46.663: libsecret_error: Failed to unlock the keyring
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: PlatformException(Libsecret error, Failed to unlock the keyring, null, null)
#0      StandardMethodCodec.decodeEnvelope (package:flutter/src/services/message_codecs.dart:648)
#1      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:334)
<asynchronous suspension>
#2      Configuration._initOnlineAccount (package:ente_auth/core/configuration.dart:116)
<asynchronous suspension>
#3      Configuration.init (package:ente_auth/core/configuration.dart:94)
<asynchronous suspension>
#4      _init (package:ente_auth/main.dart:170)
<asynchronous suspension>
#5      _runInForeground.<anonymous closure> (package:ente_auth/main.dart:113)
<asynchronous suspension>
#6      SuperLogging.main (package:ente_auth/core/logging/super_logging.dart:201)
<asynchronous suspension>
#7      _runWithLogs (package:ente_auth/main.dart:142)
<asynchronous suspension>
#8      _runInForeground (package:ente_auth/main.dart:111)
<asynchronous suspension>
#9      main (package:ente_auth/main.dart:90)
<asynchronous suspension>
```
