### PR TITLE
Use libusb and gudev modules from runtime

### DIFF
--- a/io.ente.auth.yml
+++ b/io.ente.auth.yml
@@ -97,31 +97,17 @@ modules:
       - type: git
         url: https://gitlab.freedesktop.org/libfprint/fprintd.git
         tag: v1.94.4
+        commit: a1ce7322372cb848f7cd6c3f499b757edd709dd2
         x-checker-data:
           type: git
           url: https://gitlab.freedesktop.org/libfprint/fprintd.git
           tag-pattern: ^v([\d.]+)$
-        commit: a1ce7322372cb848f7cd6c3f499b757edd709dd2
     build-commands:
       - meson setup builddir --prefix=${FLATPAK_DEST} -Dpam=false -Dman=false -Dsystemd=false
       - ninja -C builddir
       - install -Dm755 builddir/utils/fprintd-verify ${FLATPAK_DEST}/bin/fprintd-verify
       - install -Dm755 builddir/utils/fprintd-list ${FLATPAK_DEST}/bin/fprintd-list
     modules:
-      - name: libusb
-        buildsystem: autotools
-        config-opts:
-          - --disable-static
-        sources:
-          - type: git
-            url: https://github.com/libusb/libusb.git
-            tag: v1.0.27
-            x-checker-data:
-              type: git
-              url: https://github.com/libusb/libusb.git
-              tag-pattern: ^v([\d.]+)$
-
-            commit: d52e355daa09f17ce64819122cb067b8a2ee0d4b
       - name: libgusb
         buildsystem: meson
         config-opts:
@@ -132,22 +118,12 @@ modules:
           - type: git
             url: https://github.com/hughsie/libgusb.git
             tag: 0.4.9
+            commit: ed31c8134d80d006bd45450e84180be2a7c0742e
             x-checker-data:
               type: git
               url: https://github.com/hughsie/libgusb.git
               tag-pattern: ^([\d.]+)$
 
-            commit: ed31c8134d80d006bd45450e84180be2a7c0742e
-      - name: gudev
-        buildsystem: meson
-        config-opts:
-          - -Dtests=disabled
-          - -Dintrospection=disabled
-          - -Dvapi=disabled
-        sources:
-          - type: archive
-            url: https://download.gnome.org/sources/libgudev/238/libgudev-238.tar.xz
-            sha256: 61266ab1afc9d73dbc60a8b2af73e99d2fdff47d99544d085760e4fa667b5dd1
 
       - name: libfprint
         buildsystem: meson
@@ -160,12 +136,11 @@ modules:
           - type: git
             url: https://gitlab.freedesktop.org/libfprint/libfprint.git
             tag: v1.94.8
+            commit: e57bab2f1ef3583158d2e6e2b5bb4182629ebe35
             x-checker-data:
               type: git
               url: https://gitlab.freedesktop.org/libfprint/libfprint.git
               tag-pattern: ^v([\d.]+)$
-
-            commit: e57bab2f1ef3583158d2e6e2b5bb4182629ebe35
 
       - name: zenity
         buildsystem: meson


### PR DESCRIPTION
GNOME runtime 49 (based on the Freedesktop runtime version 25.08) appears to provide the libgudev/gudev and libusb modules.

Fixes: https://github.com/flathub/io.ente.auth/issues/94
Fixes: https://github.com/flathub/io.ente.auth/issues/92