### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/io.ente.auth.yml
+++ b/io.ente.auth.yml
@@ -25,9 +25,13 @@ rename-appdata-file: enteauth.appdata.xml
 rename-desktop-file: enteauth.desktop
 rename-icon: enteauth
 cleanup:
-  - /lib/*.la
-  - /lib/pkgconfig
+  - '*.a'
+  - '*.la'
   - /include
+  - /lib/pkgconfig
+  - /share/help
+  - /share/man
+  - /share/vala
 modules:
   - shared-modules/libappindicator/libappindicator-gtk3-12.10.json
   - shared-modules/libsoup/libsoup-2.4.json


### PR DESCRIPTION
Ente app opens an external website for help documentation.

Therefore, it's not required to keep the /share/help folder.

Also, remove development related folders to reduce the Flatpak size.