### PR TITLE
Remove stale AppData line deletion workaround

### DIFF
--- a/io.ente.auth.yml
+++ b/io.ente.auth.yml
@@ -111,7 +111,6 @@ modules:
       - ln -s /app/lib/libappindicator3.so /app/lib/libayatana-ido3-0.4.so.0
       - bsdtar --to-stdout -xf ente-auth.deb data.* | bsdtar -xf -
       - cp -a usr/share/. ${FLATPAK_DEST}/share/ && rm -rf usr/share
-      - sed -i '21d' ${FLATPAK_DEST}/share/metainfo/enteauth.appdata.xml
       - ARCH_TRIPLE=$(gcc --print-multiarch) && ln -s /usr/lib/${ARCH_TRIPLE}/libsqlite3.so.0
         ${FLATPAK_DEST}/lib/libsqlite3.so
       - ln -s ${FLATPAK_DEST}/share/enteauth/enteauth ${FLATPAK_DEST}/bin/enteauth


### PR DESCRIPTION
From what I can gather, it was added in https://github.com/flathub/io.ente.auth/commit/75f9a7974a1cda5beec7e81de4515a8cf25fa228 as a way to get the release versioning related checks pass. Now that reason is not valid anymore, and is also deleting legit versions.