### PR TITLE
Drop stale bundled libsodium

### DIFF
--- a/io.ente.auth.yml
+++ b/io.ente.auth.yml
@@ -35,16 +35,6 @@ cleanup:
 modules:
   - shared-modules/libappindicator/libappindicator-gtk3-12.10.json
 
-  - name: libsodium
-    sources:
-      - type: archive
-        url: https://github.com/jedisct1/libsodium/archive/1.0.18-RELEASE.tar.gz
-        sha256: b7292dd1da67a049c8e78415cd498ec138d194cfdb302e716b08d26b80fecc10
-        x-checker-data:
-          type: anitya
-          project-id: 1728
-          url-template: https://github.com/jedisct1/libsodium/archive/$version.tar.gz
-
   - name: fprintd
     buildsystem: simple
     sources:


### PR DESCRIPTION
Removes the stale Flathub libsodium module so the Flatpak no longer injects an older libsodium into /app/lib. The app ships its own libsodium.